### PR TITLE
Update manifest version to allow chrome store download again, regex error 

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,7 +1,7 @@
-chrome.extension.onRequest.addListener(
-  function(request, sender, sendResponse) {
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     if (request.get_options) {
-      chrome.storage.sync.get(null, sendResponse);
+      chrome.storage.sync.get(null).then(sendResponse);
+      return true;
     } else {
       sendResponse({});
     }

--- a/manifest.json
+++ b/manifest.json
@@ -2,8 +2,8 @@
   "name": "Type-ahead-find",
   "description": "Find text or links as you type",
   "version": "0.4.5",
-  "manifest_version": 2,
-  "background": {"scripts": ["background.js"]},
+  "manifest_version": 3,
+  "background": {"service_worker": "background.js"},
   "options_page": "options.html",
   "permissions": ["storage"],
   "content_scripts": [

--- a/type-ahead.js
+++ b/type-ahead.js
@@ -285,7 +285,7 @@ function processSearch(search, options) {
   }
   
   var matchedElements = new Array();
-  var string = escape_regexp(search.text).replace(/\s+/g, "(\\s|\240)+");
+  var string = escape_regexp(search.text).replace(/\s+/g, "(\\s|\xa0)+");
   if (options.starts_link_only)
     string = '^' + string;
   // If string is lower case, search will be case-unsenstive.


### PR DESCRIPTION
Chrome not allowing downloads due to manifest version and service workers, version and background update caused JS regex space issue changed from octal to hexadecimal, no other impacts to functionality from regex represents same character. 
Tested in Chrome extensions dev
Issue: #16 